### PR TITLE
Fix: updated makefile to docker compose V2 syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,30 +3,30 @@ VOLUME=$(shell basename $(PWD))
 develop: clean build migrations.run run
 
 clean:
-	docker-compose rm -vf
+	docker compose rm -vf
 
 build:
-	docker-compose build
+	docker compose build
 
 run:
-	docker-compose up
+	docker compose up
 
 shell:
-	docker-compose run express \
+	docker compose run express \
 		sh
 
 postgres.data.delete: clean
 	docker volume rm $(VOLUME)_postgres
 
 postgres.start:
-	docker-compose up -d postgres
-	docker-compose exec postgres \
+	docker compose up -d postgres
+	docker compose exec postgres \
 		sh -c 'while ! nc -z postgres 5432; do sleep 0.1; done'
 
 migrations.blank:
-	docker-compose up -d express
-	docker-compose exec express npx sequelize-cli migration:generate --name migration-skeleton
+	docker compose up -d express
+	docker compose exec express npx sequelize-cli migration:generate --name migration-skeleton
 
 migrations.run:
-	docker-compose up -d express
-	docker-compose exec express npx sequelize-cli db:migrate
+	docker compose up -d express
+	docker compose exec express npx sequelize-cli db:migrate


### PR DESCRIPTION
**Description**
Makefile failing due to referencing V1 docker compose
V1 no longer supported by [Docker](https://docs.docker.com/compose/migrate/)

**Issue**
Closes #6 